### PR TITLE
Adds migrations for Citext Column Type, Adds Serializer Gem & Merchant Serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'puma', '~> 3.7'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'active_model_serializers', '~> 0.10.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.1.4)
       activesupport (= 5.1.4)
       globalid (>= 0.3.6)
@@ -50,6 +55,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
@@ -65,6 +72,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -163,6 +171,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   byebug
   capybara
   factory_bot_rails

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,3 @@
+class MerchantSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/db/migrate/20171129144146_change_first_name_to_citext_on_customers.rb
+++ b/db/migrate/20171129144146_change_first_name_to_citext_on_customers.rb
@@ -1,0 +1,7 @@
+class ChangeFirstNameToCitextOnCustomers < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :customers, :first_name, :citext
+  end
+end

--- a/db/migrate/20171129144224_change_last_name_to_citext_on_customers.rb
+++ b/db/migrate/20171129144224_change_last_name_to_citext_on_customers.rb
@@ -1,0 +1,7 @@
+class ChangeLastNameToCitextOnCustomers < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :customers, :last_name, :citext
+  end
+end

--- a/db/migrate/20171129144402_change_status_to_citext_on_invoices.rb
+++ b/db/migrate/20171129144402_change_status_to_citext_on_invoices.rb
@@ -1,0 +1,7 @@
+class ChangeStatusToCitextOnInvoices < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :invoices, :status, :citext
+  end
+end

--- a/db/migrate/20171129144611_change_name_to_citext_on_items.rb
+++ b/db/migrate/20171129144611_change_name_to_citext_on_items.rb
@@ -1,0 +1,7 @@
+class ChangeNameToCitextOnItems < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :items, :name, :citext
+  end
+end

--- a/db/migrate/20171129144735_change_description_to_citext_on_items.rb
+++ b/db/migrate/20171129144735_change_description_to_citext_on_items.rb
@@ -1,0 +1,7 @@
+class ChangeDescriptionToCitextOnItems < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :items, :description, :citext
+  end
+end

--- a/db/migrate/20171129145031_change_result_to_citext_on_transactions.rb
+++ b/db/migrate/20171129145031_change_result_to_citext_on_transactions.rb
@@ -1,0 +1,7 @@
+class ChangeResultToCitextOnTransactions < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'citext'
+
+    change_column :transactions, :result, :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129144224) do
+ActiveRecord::Schema.define(version: 20171129144402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20171129144224) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.string "status"
+    t.citext "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "merchant_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129144735) do
+ActiveRecord::Schema.define(version: 20171129145031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20171129144735) do
   create_table "transactions", force: :cascade do |t|
     t.integer "invoice_id"
     t.string "credit_card_number"
-    t.string "result"
+    t.citext "result"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "credit_card_expiration_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129144402) do
+ActiveRecord::Schema.define(version: 20171129144611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20171129144402) do
   end
 
   create_table "items", force: :cascade do |t|
-    t.string "name"
+    t.citext "name"
     t.float "unit_price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171128213807) do
+ActiveRecord::Schema.define(version: 20171129144224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "citext"
 
   create_table "customers", force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
+    t.citext "first_name"
+    t.citext "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129144611) do
+ActiveRecord::Schema.define(version: 20171129144735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20171129144611) do
     t.float "unit_price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "description"
+    t.citext "description"
     t.bigint "merchant_id"
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end


### PR DESCRIPTION
1. Adds migrations to change column types to citext (case insensitve text).
- There are 6 new migrations that account for this change.

2. Adds serializer gem with new directory for serializers. Adds serializer for merchant to only render id and name. The spec harness for merchant_endpoints are all passing now.
- requires a bundle to get the serializer gem.