### PR TITLE
Most Sold Items Endpoint: GET /api/v1/items/most_items?quantity=x

### DIFF
--- a/app/controllers/api/v1/items/most_sold_items_controller.rb
+++ b/app/controllers/api/v1/items/most_sold_items_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::MostSoldItemsController < ApplicationController
+
+  def index
+    render json: Item.most_sold_items(params[:quantity].to_i)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,11 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
+
+  def self.most_sold_items(quantity = 5)
+    select('items.*, sum(invoice_items.quantity) as total_sold')
+    .joins(:invoices)
+    .group(:id)
+    .order('total_sold desc').limit(quantity)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
         get '/find', to: 'find#show'
         get '/find_all', to: 'find#index'
         get '/random', to: 'random#show'
+        get '/most_items', to: 'most_sold_items#index'
       end
 
       namespace :invoices do

--- a/spec/requests/api/v1/items/most_sold_items_spec.rb
+++ b/spec/requests/api/v1/items/most_sold_items_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "Items API" do
+  describe "get /api/v1/items/most_items?quantity=x" do
+    it "returns the top x number of items" do
+      merchant = create(:merchant)
+      item1 = create(:item, name: "Item1", unit_price: 10000)
+      item2 = create(:item, name: "Item2", unit_price: 20012)
+      item3 = create(:item, name: "Item3", unit_price: 2500)
+      merchant.items << [item1, item2, item3]
+      invoice1 = create(:invoice, status: 'shipped', merchant: merchant)
+      invoice2 = create(:invoice, status: 'shipped', merchant: merchant)
+      invoice3 = create(:invoice, status: 'shipped', merchant: merchant)
+      item1.invoice_items << create(:invoice_item, invoice: invoice1, quantity: 3, unit_price: item1.unit_price)
+      item1.invoice_items << create(:invoice_item, invoice: invoice2, quantity: 2, unit_price: item1.unit_price)
+      item2.invoice_items << create(:invoice_item, invoice: invoice1, quantity: 1, unit_price: item2.unit_price)
+      item3.invoice_items << create(:invoice_item, invoice: invoice3, quantity: 2, unit_price: item3.unit_price)
+      transaction1 = create(:transaction, invoice: invoice1, result: 'success')
+      transaction2 = create(:transaction, invoice: invoice2, result: 'success')
+      transaction3 = create(:transaction, invoice: invoice3, result: 'success')
+
+      get "/api/v1/items/most_items?quantity=2"
+
+      top_items = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(top_items[0]['name']).to eq("Item1")
+      expect(top_items[0]['id']).to eq(item1.id)
+      expect(top_items[1]['name']).to eq("Item3")
+      expect(top_items[1]['id']).to eq(item3.id)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the functionality to find a variable amount of most sold items.

tested in spec/requests/api/v1/items/most_sold_items_spec.rb
Adds namespaced route under items to '/most_items' that routes to a MostSoldItemsController, index action.

GET /api/v1/items/most_items?quantity=x

closes #36 
