### PR TITLE
Customer Record endpoints: find, find_all, random

### DIFF
--- a/app/controllers/api/v1/customers/find_controller.rb
+++ b/app/controllers/api/v1/customers/find_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::Customers::FindController < ApplicationController
+
+  def index
+    render json: Customer.where(customer_params)
+  end
+
+  def show
+    render json: Customer.find_by(customer_params)
+  end
+
+  private
+
+  def customer_params
+    params.permit(:id, :first_name, :last_name, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/customers/random_controller.rb
+++ b/app/controllers/api/v1/customers/random_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Customers::RandomController < ApplicationController
+
+  def show
+    render json: Customer.order("RANDOM()").first
+  end
+
+end

--- a/app/serializers/customer_serializer.rb
+++ b/app/serializers/customer_serializer.rb
@@ -1,0 +1,3 @@
+class CustomerSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,12 @@ Rails.application.routes.draw do
         get '/:id/favorite_customer', to: 'favorite#show'
       end
 
+      namespace :customers do
+        get 'find', to: 'find#show'
+        get '/find_all', to: 'find#index'
+        get '/random', to: 'random#show'
+      end
+
       resources :invoices, only: [:index, :show]
       resources :items, only: [:index, :show] do
         get '/best_day', to: 'best_day#show'

--- a/spec/requests/api/v1/customers/customers_api_spec.rb
+++ b/spec/requests/api/v1/customers/customers_api_spec.rb
@@ -24,4 +24,89 @@ describe "Customers API" do
     expect(parsed_customer[:first_name]).to eq(customer1.first_name)
     expect(parsed_customer[:last_name]).to_not eq(customer2.last_name)
   end
+
+  describe "finds a single customer by parameters" do
+    context "that are case insensitive"
+    it "finds a customer by first_name in all caps" do
+      customer1, customer2 = create_list(:customer, 2)
+
+      get "/api/v1/customers/find?name=#{customer1.first_name.upcase}"
+
+      parsed_customer = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customer).to have_key(:first_name)
+      expect(parsed_customer[:id]).to eq(customer1.id)
+      expect(parsed_customer[:first_name]).to eq(customer1.first_name)
+      expect(parsed_customer[:first_name]).to_not eq(customer2.first_name)
+    end
+
+    it "finds a customer by last_name with all lowercase" do
+      customer1, customer2 = create_list(:customer, 2)
+
+      get "/api/v1/customers/find?last_name=#{customer2.last_name.swapcase}"
+
+      parsed_customer = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customer).to have_key(:last_name)
+      expect(parsed_customer[:id]).to eq(customer2.id)
+      expect(parsed_customer[:last_name]).to eq(customer2.last_name)
+      expect(parsed_customer[:last_name]).to_not eq(customer1.last_name)
+    end
+
+    it "finds customer by id" do
+      customer1, customer2 = create_list(:customer, 2)
+
+      get "/api/v1/customers/find?id=#{customer1.id}"
+
+      parsed_customer = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customer).to have_key(:last_name)
+      expect(parsed_customer[:id]).to eq(customer1.id)
+      expect(parsed_customer[:last_name]).to eq(customer1.last_name)
+      expect(parsed_customer[:last_name]).to_not eq(customer2.last_name)
+    end
+  end
+
+  describe "it finds a collection of customers with search parameters" do
+    it "finds all customers by id" do
+      customer1, customer2, customer3 = create_list(:customer, 3)
+
+      get "/api/v1/customers/find_all?id=#{customer3.id}"
+
+      parsed_customers = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customers.class).to eq(Array)
+      expect(parsed_customers[0][:first_name]).to eq(customer3.first_name)
+    end
+
+    it "finds all customers by last_name" do
+      customer1, customer2, customer3 = create_list(:customer, 3)
+
+      get "/api/v1/customers/find_all?last_name=#{customer2.last_name}"
+
+      parsed_customers = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customers.class).to eq(Array)
+      expect(parsed_customers[0][:last_name]).to eq(customer2.last_name)
+    end
+  end
+
+  describe "/api/v1/customers/random" do
+    it "returns a random customer" do
+      customers = create_list(:customer, 3)
+      customer_names = customers.map {|customer| customer.last_name}
+
+      get "/api/v1/customers/random"
+
+      random_customer = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(customer_names).to include(random_customer[:last_name])
+    end
+  end
 end

--- a/spec/requests/api/v1/merchants/merchants_api_spec.rb
+++ b/spec/requests/api/v1/merchants/merchants_api_spec.rb
@@ -67,14 +67,6 @@ describe "Merchants API" do
       expect(parsed_merchant[:name]).to eq(merchant1.name)
       expect(parsed_merchant[:name]).to_not eq(merchant2.name)
     end
-
-    xit "finds merchant by created_at" do
-
-    end
-
-    xit "finds merchant by updated_at" do
-
-    end
   end
 
   describe "it finds a collection of merchants with search parameters" do
@@ -100,12 +92,6 @@ describe "Merchants API" do
       expect(response).to be_success
       expect(parsed_merchants.class).to eq(Array)
       expect(parsed_merchants[0][:name]).to eq(merchant2.name)
-    end
-
-    xit "finds all merchants by created_at date" do
-    end
-
-    xit "finds all merchants by updated_at date" do
     end
   end
 


### PR DESCRIPTION
This PR adds the basic record endpoints for customers.

It adds two namespaced controllers (find, random) in customers.
This is tested in spec/requests/api/v1/customers/customers_api_spec.rb
It adds a serializer to render only id, first_name, and last_name.

GET /api/v1/customers.json
GET /api/v1/customers/1.json
GET /api/v1/customers/find?parameters
GET /api/v1/customers/find_all?parameters
GET api/v1/customers/random.json