### PR TITLE
Transactions Record endpoints: find, find_all, random

### DIFF
--- a/app/controllers/api/v1/transactions/find_controller.rb
+++ b/app/controllers/api/v1/transactions/find_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::Transactions::FindController < ApplicationController
+
+  def index
+    render json: Transaction.where(transaction_params)
+  end
+
+  def show
+    render json: Transaction.find_by(transaction_params)
+  end
+
+  private
+
+  def transaction_params
+    params.permit(:id,
+                  :invoice_id,
+                  :credit_card_number,
+                  :result,
+                  :created_at,
+                  :updated_at,
+                  :credit_card_expiration_date)
+  end
+end

--- a/app/controllers/api/v1/transactions/random_controller.rb
+++ b/app/controllers/api/v1/transactions/random_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Transactions::RandomController < ApplicationController
+
+  def show
+    render json: Transaction.order("RANDOM()").first
+  end
+
+end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,0 +1,3 @@
+class TransactionSerializer < ActiveModel::Serializer
+  attributes :id, :invoice_id, :result, :credit_card_number
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,12 @@ Rails.application.routes.draw do
         get '/random', to: 'random#show'
       end
 
+      namespace :transactions do
+        get 'find', to: 'find#show'
+        get '/find_all', to: 'find#index'
+        get '/random', to: 'random#show'
+      end
+
       resources :invoices, only: [:index, :show]
       resources :items, only: [:index, :show] do
         get '/best_day', to: 'best_day#show'

--- a/spec/requests/api/v1/transactions/transactions_api_spec.rb
+++ b/spec/requests/api/v1/transactions/transactions_api_spec.rb
@@ -26,4 +26,73 @@ describe "Transactions API" do
     expect(parsed_transaction1[:id]).to eq(transaction1.id)
     expect(parsed_transaction1[:id]).to_not eq(transaction2.id)
   end
+
+  describe "finds a single transaction by parameters" do
+    context "that are case insensitive"
+    it "finds a transaction by result in all caps" do
+      transaction1, transaction2 = create_list(:transaction, 2)
+
+      get "/api/v1/transactions/find?result=#{transaction1.result.upcase}"
+
+      parsed_transaction = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_transaction).to have_key(:result)
+      expect(parsed_transaction[:id]).to eq(transaction1.id)
+      expect(parsed_transaction[:result]).to eq(transaction1.result)
+    end
+
+    it "finds transaction by id" do
+      transaction1, transaction2 = create_list(:transaction, 2)
+
+      get "/api/v1/transactions/find?id=#{transaction1.id}"
+
+      parsed_transaction = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_transaction).to have_key(:id)
+      expect(parsed_transaction[:id]).to eq(transaction1.id)
+      expect(parsed_transaction[:result]).to eq(transaction1.result)
+    end
+  end
+
+  describe "it finds a collection of transactions with search parameters" do
+    it "finds all transactions by id" do
+      transaction1, transaction2, transaction3 = create_list(:transaction, 3)
+
+      get "/api/v1/transactions/find_all?id=#{transaction3.id}"
+
+      parsed_customers = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customers.class).to eq(Array)
+      expect(parsed_customers[0][:id]).to eq(transaction3.id)
+    end
+
+    it "finds all transactions by invoice_id" do
+      transaction1, transaction2, transaction3 = create_list(:transaction, 3)
+
+      get "/api/v1/transactions/find_all?invoice_id=#{transaction2.invoice_id}"
+
+      parsed_customers = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_customers.class).to eq(Array)
+      expect(parsed_customers[0][:invoice_id]).to eq(transaction2.invoice_id)
+    end
+  end
+
+  describe "/api/v1/transactions/random" do
+    it "returns a random transaction" do
+      transactions = create_list(:transaction, 3)
+      transaction_ids = transactions.map {|transaction| transaction.id}
+
+      get "/api/v1/transactions/random"
+
+      random_transaction = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(transaction_ids).to include(random_transaction[:id])
+    end
+  end
 end

--- a/spec/requests/api/v1/transactions/transactions_api_spec.rb
+++ b/spec/requests/api/v1/transactions/transactions_api_spec.rb
@@ -54,6 +54,19 @@ describe "Transactions API" do
       expect(parsed_transaction[:id]).to eq(transaction1.id)
       expect(parsed_transaction[:result]).to eq(transaction1.result)
     end
+
+    it "finds transaction by credit_card_number" do
+      create(:transaction, credit_card_number: "4187236528793125")
+      transaction2 = create(:transaction, credit_card_number: "0910934023090923")
+
+      get "/api/v1/transactions/find?credit_card_number=#{transaction2.credit_card_number}"
+
+      parsed_transaction = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_success
+      expect(parsed_transaction).to have_key(:credit_card_number)
+      expect(parsed_transaction[:credit_card_number]).to eq(transaction2.credit_card_number)
+    end
   end
 
   describe "it finds a collection of transactions with search parameters" do


### PR DESCRIPTION
This PR adds the basic record endpoints for transactions.

It adds two namespaced controllers (find, random) in transactions.
This is tested in spec/requests/api/v1/transactions/transactions_api_spec.rb
It adds a serializer to render appropriate attributes

GET /api/v1/transactions.json
GET /api/v1/transactions/1.json
GET /api/v1/transactions/find?parameters
GET /api/v1/transactions/find_all?parameters
GET api/v1/transactions/random.json