### PR TITLE
Customer Favorite Merchant Endpoint: GET /api/v1/customers/:id/favorite_merchant

### DIFF
--- a/app/controllers/api/v1/customer_favorite_merchant_controller.rb
+++ b/app/controllers/api/v1/customer_favorite_merchant_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::CustomerFavoriteMerchantController < ApplicationController
+
+  def show
+    render json: customer.favorite_merchant
+  end
+
+  private
+
+  def customer
+    Customer.find(params[:customer_id])
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,3 +1,16 @@
 class Customer < ApplicationRecord
   has_many :invoices
+  has_many :merchants, through: :invoices
+
+  def favorite_merchant
+    merchants
+    .select('merchants.*, sum(transactions.id) AS num_transactions')
+    .joins(invoices: [:transactions, :merchant])
+    .merge(Transaction.successful)
+    .group('merchants.id')
+    .order('num_transactions desc')
+    .limit(1)
+    .first
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,7 +2,7 @@ class Merchant < ApplicationRecord
 
   has_many :items
   has_many :invoices
-
+  has_many :customers, through: :invoices
 
   def favorite_customer
     Customer.left_joins(invoices: :transactions)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,9 @@ Rails.application.routes.draw do
          get '/revenue', to: 'revenue#show'
       end
       resources :transactions, only: [:index, :show]
-      resources :customers, only: [:index, :show]
+      resources :customers, only: [:index, :show] do
+        get '/favorite_merchant', to: 'customer_favorite_merchant#show'
+      end
     end
   end
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,4 +2,25 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
   it { should have_many(:invoices) }
+
+  describe '#favorite_merchant' do
+    it 'returns the merchant where the customer has completed the most successful transactions' do
+      customer = create :customer
+      merchant1 = create :merchant
+      merchant2 = create :merchant
+
+      item1 = create :item, merchant: merchant1
+      invoice1 = create :invoice, merchant: merchant1, customer: customer
+      create :invoice_item, invoice: invoice1, item: item1, quantity: 1
+      create :transaction, invoice: invoice1
+
+      item2 = create :item, merchant: merchant2
+      invoice2 = create :invoice, merchant: merchant2, customer: customer
+      create :invoice_item, invoice: invoice2, item: item2, quantity: 2
+      create :transaction, invoice: invoice2
+
+
+      expect(customer.favorite_merchant).to eq merchant2
+    end
+  end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Customer, type: :model do
       create :invoice_item, invoice: invoice2, item: item2, quantity: 2
       create :transaction, invoice: invoice2
 
-
       expect(customer.favorite_merchant).to eq merchant2
     end
   end

--- a/spec/requests/api/v1/customers/favorite_merchant_spec.rb
+++ b/spec/requests/api/v1/customers/favorite_merchant_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "Customers API" do
+  describe "GET /api/v1/customers/:id/favorite_merchant" do
+    it 'calls favorite_merchant on customer and returns the favorite merchant' do
+
+      customer = double()
+      merchant = create :merchant
+
+      allow(Customer).to receive(:find).with('1') { customer }
+      expect(customer).to receive(:favorite_merchant).once
+
+      get '/api/v1/customers/1/favorite_merchant'
+
+      parsed_favorite_merchant = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(parsed_favorite_merchant['id']).to eq merchant.id
+      expect(parsed_favorite_merchant['name']).to eq merchant.name
+    end
+  end
+end

--- a/spec/requests/api/v1/customers/favorite_merchant_spec.rb
+++ b/spec/requests/api/v1/customers/favorite_merchant_spec.rb
@@ -8,7 +8,7 @@ describe "Customers API" do
       merchant = create :merchant
 
       allow(Customer).to receive(:find).with('1') { customer }
-      expect(customer).to receive(:favorite_merchant).once
+      expect(customer).to receive(:favorite_merchant).once { merchant }
 
       get '/api/v1/customers/1/favorite_merchant'
 


### PR DESCRIPTION
This PR adds the endpoint for a customer's favorite merchant.

It adds has_many relationships on customers and merchants through invoices in order to return a merchant object when calling favorite_merchant on a customer.

Spec Harness passes!